### PR TITLE
Fix createCoreData()

### DIFF
--- a/.Renviron
+++ b/.Renviron
@@ -1,1 +1,1 @@
-R_USER="C:/Users/Evan/Desktop/Conte"
+#R_USER="C:/Users/Evan/Desktop/Conte"

--- a/getWBData/R/createCoreData.R
+++ b/getWBData/R/createCoreData.R
@@ -75,11 +75,14 @@ createCoreData<-function(sampleType="electrofishing",
 #add data from each table
   for(t in tables){
     #select only columns that exist in each table
-    tableColumns<-DBI::dbGetQuery(con,
-                  paste0("SELECT column_name ",
-                        "FROM information_schema.columns ",
-                        "WHERE table_name = '",t,"'")
-                  )$column_name
+    # tableColumns<-DBI::dbGetQuery(con,
+    #               paste0("SELECT column_name ",
+    #                     "FROM information_schema.columns ",
+    #                     "WHERE table_name = '",t,"'")
+    #               )$column_name
+    tableColumns <- tbl(con, t) %>% 
+      collect(1) %>% 
+      names()
     if(t=="data_untagged_captures"){
       chosenTableColumns<-match(c(chosenColumns,"species","cohort"),
                                 tableColumns,nomatch=0) %>% .[.>0]


### PR DESCRIPTION
Fixed `createCoreData()` that previously used `information_schema` table to determine column ordering. Now determines column order by fetching one row from the table and extracting the column names.  